### PR TITLE
fix(xplr): align values of nested object

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Configuration options include:
 ```toml
 # format
 ExpandShape = "╰─"
-LeafShape = "🯒🯑"
+LeafShape = "❂"
 SpacesPerLayer = 2
+MergedObjectOverride = "" # if set, will not show a merged representation of a nested object
 # colors
 ExpandShapeColor = "#d99c63"
 LeafShapeColor = "#d19359"

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -97,29 +97,37 @@ func makeNode(key string, value any, layer uint, displayLayers uint) *Node {
 		Key:    key,
 		Expand: layer < displayLayers,
 	}
-	switch value.(type) {
+	switch v := value.(type) {
 	case string:
-		node.Value = value.(string)
+		node.Value = v
 	case int:
-		node.Value = strconv.FormatInt(int64(value.(int)), 10)
+		node.Value = strconv.FormatInt(int64(v), 10)
 	case float64:
-		node.Value = strconv.FormatFloat(value.(float64), 'f', -1, 64)
+		node.Value = strconv.FormatFloat(v, 'f', -1, 64)
 	case bool:
-		node.Value = strconv.FormatBool(value.(bool))
+		node.Value = strconv.FormatBool(v)
 	case []any:
-		node.Children = make([]*Node, 0, len(value.([]any)))
-		for i, child := range value.([]any) {
+		node.Children = make([]*Node, 0, len(v))
+		for i, child := range v {
 			childNode := makeNode(strconv.FormatUint(uint64(i), 10), child, layer+1, displayLayers)
 			childNode.Parent = node
 			node.Children = append(node.Children, childNode)
 		}
-		node.Value = node.ShortString()
+		if len(v) == 0 {
+			node.Value = "[]"
+		} else {
+			node.Value = node.ShortString()
+		}
 	case map[string]any:
-		node.Children = makeTree(value.(map[string]any), layer+1, displayLayers)
+		node.Children = makeTree(v, layer+1, displayLayers)
 		for _, n := range node.Children {
 			n.Parent = node
 		}
-		node.Value = node.ShortString()
+		if len(v) == 0 {
+			node.Value = "{}"
+		} else {
+			node.Value = node.ShortString()
+		}
 	}
 	return node
 }

--- a/internal/styles/config.go
+++ b/internal/styles/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type StyleConfig struct {
-	ExpandShape    string
-	LeafShape      string
-	SpacesPerLayer int
+	ExpandShape          string
+	LeafShape            string
+	SpacesPerLayer       int
+	MergedObjectOverride string
 	// colors
 	ExpandShapeColor          string
 	LeafShapeColor            string

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -16,14 +16,15 @@ const (
 )
 
 type Style struct {
-	ExpandShape    string
-	LeafShape      string
-	SpacesPerLayer int
-	LeafShapes     lipgloss.Style
-	ExpandShapes   lipgloss.Style
-	Selected       lipgloss.Style
-	Unselected     lipgloss.Style
-	Help           lipgloss.Style
+	ExpandShape          string
+	LeafShape            string
+	SpacesPerLayer       int
+	MergedObjectOverride string
+	LeafShapes           lipgloss.Style
+	ExpandShapes         lipgloss.Style
+	Selected             lipgloss.Style
+	Unselected           lipgloss.Style
+	Help                 lipgloss.Style
 }
 
 func NewStyle(c *StyleConfig) Style {
@@ -36,6 +37,9 @@ func NewStyle(c *StyleConfig) Style {
 	}
 	if c.SpacesPerLayer > 0 {
 		style.SpacesPerLayer = c.SpacesPerLayer
+	}
+	if c.MergedObjectOverride != "" {
+		style.MergedObjectOverride = c.MergedObjectOverride
 	}
 	if c.LeafShapeColor != "" {
 		fmt.Printf("LeafShapeColor: %s\n", c.LeafShapeColor)


### PR DESCRIPTION
This makes the values of a nested object uniformly aligned. Addresses #12.

Does some other things, see the comments as well as this demo:

https://github.com/user-attachments/assets/f92c9a84-70cc-45bb-89bd-d2d3140a9e51




