### PR TITLE
chore(xplr) break node string repr into generic function

### DIFF
--- a/cmds/cmd.go
+++ b/cmds/cmd.go
@@ -65,7 +65,8 @@ func New() *cobra.Command {
 				return fmt.Errorf("no data")
 			}
 			// parse into node tree
-			n := nodes.New(m, layers)
+			// TODO make stringify function configurable
+			n := nodes.New(m, layers, nodes.LeafValuesOnly)
 			// parse configs
 			keyMap := keys.NewKeyMap(&c.KeyConfig)
 			style := styles.NewStyle(&c.StyleConfig)

--- a/internal/nodes/nodes_test.go
+++ b/internal/nodes/nodes_test.go
@@ -2,155 +2,10 @@ package nodes
 
 import (
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestString(t *testing.T) {
-	tests := []struct {
-		name     string
-		node     *Node
-		expected string
-	}{
-		{
-			name: "simple node",
-			node: &Node{
-				Key:   "test",
-				Value: "value",
-			},
-			expected: "test: value",
-		},
-		{
-			name: "node with children",
-			node: &Node{
-				Key: "parent",
-				Children: []*Node{
-					{Key: "child1", Value: "value1"},
-					{Key: "child2", Value: "value2"},
-				},
-			},
-			expected: "parent: {child1: value1 child2: value2}",
-		},
-		{
-			name: "nested children",
-			node: &Node{
-				Key: "root",
-				Children: []*Node{
-					{
-						Key: "level1",
-						Children: []*Node{
-							{Key: "level2", Value: "value"},
-						},
-					},
-				},
-			},
-			expected: "root: {level1: {level2: value}}",
-		},
-		{
-			name: "empty children",
-			node: &Node{
-				Key:      "empty",
-				Children: []*Node{},
-			},
-			expected: "empty",
-		},
-		{
-			name: "long string truncation",
-			node: &Node{
-				Key:   "long",
-				Value: strings.Repeat("a", MaxStringLength+10),
-			},
-			expected: "long: " + strings.Repeat("a", MaxStringLength-6) + "...",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.node.String()
-			if result != tt.expected {
-				t.Errorf("String() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestShortString(t *testing.T) {
-	tests := []struct {
-		name     string
-		node     *Node
-		expected string
-	}{
-		{
-			name: "simple leaf node",
-			node: &Node{
-				Key:   "test",
-				Value: "value",
-			},
-			expected: "value",
-		},
-		{
-			name: "node with leaf children",
-			node: &Node{
-				Key: "parent",
-				Children: []*Node{
-					{Key: "child1", Value: "value1"},
-					{Key: "child2", Value: "value2"},
-				},
-			},
-			expected: "value1 value2",
-		},
-		{
-			name: "mixed leaf and non-leaf children",
-			node: &Node{
-				Key: "root",
-				Children: []*Node{
-					{
-						Key: "nonleaf",
-						Children: []*Node{
-							{Key: "nested", Value: "value"},
-						},
-					},
-					{Key: "leaf", Value: "leafvalue"},
-				},
-			},
-			expected: "value leafvalue",
-		},
-		{
-			name: "no leaf children",
-			node: &Node{
-				Key: "root",
-				Children: []*Node{
-					{
-						Key: "level1",
-						Children: []*Node{
-							{Key: "level2", Children: []*Node{}},
-						},
-					},
-				},
-			},
-			expected: "",
-		},
-		{
-			name: "long string truncation",
-			node: &Node{
-				Key:   "long",
-				Value: strings.Repeat("a", MaxStringLength+10),
-			},
-			expected: strings.Repeat("a", MaxStringLength) + "...",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.node.ShortString()
-			if result != tt.expected {
-				t.Errorf("ShortString() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestMakeNode(t *testing.T) {
 	tests := []struct {
@@ -197,7 +52,7 @@ func TestMakeNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			node := makeNode(tt.key, tt.value, 0, 2)
+			node := makeNode(tt.key, tt.value, 0, 2, LeafValuesOnly)
 			sort.Slice(node.Children, sortNodes(node.Children))
 			assert.True(t, compareNodes(node, &tt.expected))
 		})
@@ -263,7 +118,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := New(tt.input, 2)
+			result := New(tt.input, 2, LeafValuesOnly)
 			sort.Slice(result, sortNodes(result))
 			if len(result) != len(tt.expected) {
 				t.Errorf("New() returned %d nodes, want %d", len(result), len(tt.expected))

--- a/internal/nodes/repr.go
+++ b/internal/nodes/repr.go
@@ -1,0 +1,65 @@
+package nodes
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// terminal will never render this many characters
+	MaxStringLength = 512
+)
+
+// ReprNode is a function that takes a Node and returns its string representation.
+type ReprNode func(n *Node) string
+
+// LeafValuesWithBrackets represents a node as the key mapped to sequence of children leaf values with brackets
+func LeafValuesWithBrackets(n *Node) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s", n.Key))
+	if len(n.Children) > 0 {
+		b.WriteString(": {")
+		first := true
+		for _, child := range n.Children {
+			b.WriteString(spacerToken(first))
+			b.WriteString(LeafValuesWithBrackets(child))
+			first = false
+		}
+		b.WriteString("}")
+	} else if n.Value != "" {
+		b.WriteString(fmt.Sprintf(": %s", n.Value))
+	}
+	s := b.String()
+	if len(s) > MaxStringLength {
+		return s[:MaxStringLength] + "..."
+	}
+	return s
+}
+
+// LeafValuesOnly represents a node as the key mapped to sequence of children leaf values
+func LeafValuesOnly(n *Node) string {
+	var b strings.Builder
+	if len(n.Children) > 0 {
+		first := true
+		for _, child := range n.Children {
+			b.WriteString(spacerToken(first))
+			b.WriteString(LeafValuesOnly(child))
+			first = false
+		}
+	} else {
+		b.WriteString(n.Value)
+	}
+	s := b.String()
+	if len(s) > MaxStringLength {
+		return s[:MaxStringLength] + "..."
+	}
+	return s
+}
+
+// spacerToken returns a space if not the first element
+func spacerToken(first bool) string {
+	if first {
+		return ""
+	}
+	return " "
+}

--- a/internal/nodes/repr_test.go
+++ b/internal/nodes/repr_test.go
@@ -1,0 +1,150 @@
+package nodes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLeafValuesWithBrackets(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *Node
+		expected string
+	}{
+		{
+			name: "simple node",
+			node: &Node{
+				Key:   "test",
+				Value: "value",
+			},
+			expected: "test: value",
+		},
+		{
+			name: "node with children",
+			node: &Node{
+				Key: "parent",
+				Children: []*Node{
+					{Key: "child1", Value: "value1"},
+					{Key: "child2", Value: "value2"},
+				},
+			},
+			expected: "parent: {child1: value1 child2: value2}",
+		},
+		{
+			name: "nested children",
+			node: &Node{
+				Key: "root",
+				Children: []*Node{
+					{
+						Key: "level1",
+						Children: []*Node{
+							{Key: "level2", Value: "value"},
+						},
+					},
+				},
+			},
+			expected: "root: {level1: {level2: value}}",
+		},
+		{
+			name: "empty children",
+			node: &Node{
+				Key:      "empty",
+				Children: []*Node{},
+			},
+			expected: "empty",
+		},
+		{
+			name: "long string truncation",
+			node: &Node{
+				Key:   "long",
+				Value: strings.Repeat("a", MaxStringLength+10),
+			},
+			expected: "long: " + strings.Repeat("a", MaxStringLength-6) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := LeafValuesWithBrackets(tt.node)
+			if result != tt.expected {
+				t.Errorf("String() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLeafValuesOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *Node
+		expected string
+	}{
+		{
+			name: "simple leaf node",
+			node: &Node{
+				Key:   "test",
+				Value: "value",
+			},
+			expected: "value",
+		},
+		{
+			name: "node with leaf children",
+			node: &Node{
+				Key: "parent",
+				Children: []*Node{
+					{Key: "child1", Value: "value1"},
+					{Key: "child2", Value: "value2"},
+				},
+			},
+			expected: "value1 value2",
+		},
+		{
+			name: "mixed leaf and non-leaf children",
+			node: &Node{
+				Key: "root",
+				Children: []*Node{
+					{
+						Key: "nonleaf",
+						Children: []*Node{
+							{Key: "nested", Value: "value"},
+						},
+					},
+					{Key: "leaf", Value: "leafvalue"},
+				},
+			},
+			expected: "value leafvalue",
+		},
+		{
+			name: "no leaf children",
+			node: &Node{
+				Key: "root",
+				Children: []*Node{
+					{
+						Key: "level1",
+						Children: []*Node{
+							{Key: "level2", Children: []*Node{}},
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "long string truncation",
+			node: &Node{
+				Key:   "long",
+				Value: strings.Repeat("a", MaxStringLength+10),
+			},
+			expected: strings.Repeat("a", MaxStringLength) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := LeafValuesOnly(tt.node)
+			if result != tt.expected {
+				t.Errorf("ShortString() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Creates generic `func(*Node) string` signature which will define how to represent a node as a string. Initial step in allowing value portion of the tree to be customized.