### PR TITLE
xplr/json: handles array files

### DIFF
--- a/cmds/cmd.go
+++ b/cmds/cmd.go
@@ -22,7 +22,7 @@ func New() *cobra.Command {
 	var file string
 	cmd := &cobra.Command{
 		Use:     "xplr [-x <layers>] [-f <file> | data]",
-		Version: "0.2.0",
+		Version: "0.2.4",
 		Short:   "Explore a tree data file with a TUI graphical interface",
 		Long:    "Takes in a tree data file (JSON, YAML, TOML) either via flag parameter, first argument, or stdin and produces TUI navigable tree to view and explore the data",
 		Example: "xplr -x 2 -f foo.json",

--- a/pkg/format/json.go
+++ b/pkg/format/json.go
@@ -2,14 +2,24 @@ package format
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
+	"strconv"
 )
 
+// ParseJson convert json byte array to map[string]any
+// if not JSON type, returns err
 func ParseJson(data []byte) (map[string]any, error) {
-	var j map[string]any
-	err := json.Unmarshal(data, &j)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall json: %w", err)
+	var mp map[string]any
+	if err := json.Unmarshal(data, &mp); err == nil {
+		return mp, nil
 	}
-	return j, nil
+	var arr []any
+	if err := json.Unmarshal(data, &arr); err == nil {
+		mp := map[string]any{}
+		for i, item := range arr {
+			mp[strconv.Itoa(i)] = item
+		}
+		return mp, nil
+	}
+	return nil, errors.New("data is not json type")
 }

--- a/pkg/format/json_test.go
+++ b/pkg/format/json_test.go
@@ -20,5 +20,62 @@ func TestParseJson(t *testing.T) {
 	assert.NoError(t, err)
 	m2, err := ParseJson(b)
 	assert.NoError(t, err)
-	reflect.DeepEqual(m, m2)
+	expected := map[string]any{
+		"foo": 1.0,
+		"bar": "two",
+		"baz": map[string]any{
+			"bad": []any{1.0, 2.0},
+		},
+	}
+	assert.True(t, reflect.DeepEqual(m2, expected))
+}
+
+func TestParseJsonMapArray(t *testing.T) {
+	m := []map[string]any{
+		{
+			"foo": 1,
+		},
+		{
+			"bar": "two",
+			"baz": map[string]any{
+				"bad": []any{1, 2},
+			},
+		},
+	}
+	b, err := json.Marshal(m)
+	assert.NoError(t, err)
+	m2, err := ParseJson(b)
+	assert.NoError(t, err)
+	expected := map[string]any{
+		"0": map[string]any{
+			"foo": 1.0,
+		},
+		"1": map[string]any{
+			"bar": "two",
+			"baz": map[string]any{
+				"bad": []any{1.0, 2.0},
+			},
+		},
+	}
+	assert.True(t, reflect.DeepEqual(m2, expected))
+}
+
+func TestParseJsonBasicArray(t *testing.T) {
+	m := []any{
+		"foo",
+		"bar",
+		"baz",
+		2,
+	}
+	b, err := json.Marshal(m)
+	assert.NoError(t, err)
+	m2, err := ParseJson(b)
+	assert.NoError(t, err)
+	expected := map[string]any{
+		"0": "foo",
+		"1": "bar",
+		"2": "baz",
+		"3": 2.0,
+	}
+	assert.True(t, reflect.DeepEqual(m2, expected))
 }


### PR DESCRIPTION
Now handles JSON with top level array (IE `[{"foo": 1}, ...]`