### PR TITLE
chore: switch to ubuntu-slim actions for cost efficiency

### DIFF
--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   go-fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
           fi
 
   go-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Switch from ubuntu-latest to ubuntu-slim as base image for cost efficiency