### PR TITLE
store children as ordered map for efficient gets

### DIFF
--- a/cmds/cmd.go
+++ b/cmds/cmd.go
@@ -90,8 +90,8 @@ func renderTree(conf *tui.Config, n []*nodes.Node) error {
 	style := styles.NewStyle(&conf.StyleConfig)
 	// populate KeyBasedStyles before creating the model so the copy it receives is complete
 	if meta, _ := nodes.GetNodeFromTree(n, []string{nodes.MetaKey}); meta != nil {
-		for _, child := range meta.Children {
-			style.KeyBasedStyles[child.Key] = lipgloss.NewStyle().Background(lipgloss.Color(child.Value))
+		for key, child := range meta.Children.Iter() {
+			style.KeyBasedStyles[key] = lipgloss.NewStyle().Background(lipgloss.Color(child.Value))
 		}
 	}
 	format := tree.NewFormat(&conf.TreeConfig)

--- a/cmds/diff.go
+++ b/cmds/diff.go
@@ -240,7 +240,7 @@ func createDiffTree(tree1, tree2 []*nodes.Node, opts ...DiffTreeOption) ([]*node
 		},
 		nodes.WithNextNodes(func(n *nodes.Node) []*nodes.Node {
 			if shouldRecurse {
-				return n.Children
+				return n.Children.Arr()
 			}
 			return nil
 		}))
@@ -266,7 +266,7 @@ func addNode(tree []*nodes.Node, path []string, n *nodes.Node) ([]*nodes.Node, e
 
 	// If remaining is empty, current is the exact target node - attach n directly.
 	if len(remaining) == 0 {
-		current.Children = append(current.Children, n)
+		current.Children.Put(n.Key, n)
 		n.Parent = current
 		return tree, nil
 	}
@@ -285,8 +285,8 @@ func addNode(tree []*nodes.Node, path []string, n *nodes.Node) ([]*nodes.Node, e
 		tree = append(tree, subtree...)
 	} else {
 		// found a node partway through path - attach subtree to it and wire parents
-		current.Children = append(current.Children, subtree...)
 		for _, s := range subtree {
+			current.Children.Put(s.Key, s)
 			s.Parent = current
 		}
 	}
@@ -297,7 +297,7 @@ func addNode(tree []*nodes.Node, path []string, n *nodes.Node) ([]*nodes.Node, e
 		return nil, fmt.Errorf("failed to find node in subtree for path: %v", path)
 	}
 
-	node.Children = append(node.Children, n)
+	node.Children.Put(n.Key, n)
 	n.Parent = node
 	return tree, nil
 }

--- a/cmds/diff_test.go
+++ b/cmds/diff_test.go
@@ -15,7 +15,11 @@ func TestCompareNodes(t *testing.T) {
 		return &nodes.Node{ID: uuid.New(), Key: key, Value: value}
 	}
 	nonLeaf := func(key string, children ...*nodes.Node) *nodes.Node {
-		return &nodes.Node{ID: uuid.New(), Key: key, Children: children}
+		n := &nodes.Node{ID: uuid.New(), Key: key}
+		for _, c := range children {
+			n.Children.Put(c.Key, c)
+		}
+		return n
 	}
 	leafArray := func(key string) *nodes.Node {
 		return nonLeaf(key, leaf("0", "a"), leaf("1", "b"))

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tiagomelo/go-clipboard v0.1.2
+	github.com/tidwall/btree v1.8.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tiagomelo/go-clipboard v0.1.2 h1:Ph2icR0vZRIj3v5ExvsGweBwsbbDUTlS6HoF40MkQD8=
 github.com/tiagomelo/go-clipboard v0.1.2/go.mod h1:kXtjJBIMimZaGbxmcKZ8+JqK+acSNf5tAJiChlZBOr8=
+github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
+github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=

--- a/pkg/modules/tree/view.go
+++ b/pkg/modules/tree/view.go
@@ -15,13 +15,10 @@ func siblingMaxKeyWidth(node *nodes.Node, rootNodes []*nodes.Node) int {
 		return 0
 	}
 
-	var siblings []*nodes.Node
-	if node.Parent == nil {
+	siblings := nodes.Siblings(node)
+	if len(siblings) == 0 {
 		// For root level nodes, siblings are all root nodes
 		siblings = rootNodes
-	} else {
-		// For other nodes, siblings are parent's children
-		siblings = node.Parent.Children
 	}
 
 	maxWidth := 0
@@ -142,7 +139,7 @@ func (m *Model) nodeRenderer(node *nodes.Node, index, availableChars int) string
 	// get an additional base style if needed
 	baseStyle := lipgloss.Style{}
 	for key, ks := range m.Styles.KeyBasedStyles {
-		if nodes.GetAncestor(node, key) != nil {
+		if nodes.Ancestor(node, key) != nil {
 			baseStyle = ks
 			break
 		}

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/crosleyzack/xplr/pkg/omap"
 	"github.com/google/uuid"
 )
 
@@ -15,8 +16,9 @@ type Node struct {
 	Key string
 	// Value is used to store the string representation of the value
 	Value string
-	// Children is the list of children nodes
-	Children []*Node
+	// Children is the set of child nodes, keyed by node key and kept in
+	// sorted key order.
+	Children omap.OMap[string, *Node]
 	// Parent of this node
 	Parent *Node
 	// Expand indicates if the node is expanded
@@ -28,17 +30,16 @@ func (n *Node) Equal(other *Node) bool {
 	return n.ID == other.ID
 }
 
-func GetChild(n *Node, key string) *Node {
-	for _, child := range n.Children {
-		if child.Key == key {
-			return child
-		}
+// Child get child node with given key
+func Child(n *Node, key string) *Node {
+	if child, ok := n.Children.Get(key); ok {
+		return child
 	}
 	return nil
 }
 
-// GetAncestor for a given node by key identifier
-func GetAncestor(n *Node, key string) *Node {
+// Ancestor for a given node by key identifier
+func Ancestor(n *Node, key string) *Node {
 	for {
 		if n.Key == key {
 			return n
@@ -50,9 +51,18 @@ func GetAncestor(n *Node, key string) *Node {
 	}
 }
 
+// Siblings get nodes with the same parent as this node
+func Siblings(n *Node) []*Node {
+	if n == nil || n.Parent == nil {
+		return nil
+	}
+
+	return n.Children.Arr()
+}
+
 // IsLeaf returns true if the node is a leaf node (has no children)
 func IsLeaf(n *Node) bool {
-	return len(n.Children) == 0
+	return n.Children.Len() == 0
 }
 
 // ToMap converts a node back to a map[string]any, which can be used to convert back to JSON
@@ -63,7 +73,7 @@ func ToMap(n []*Node) map[string]any {
 			m[n.Key] = n.Value
 			continue
 		}
-		m[n.Key] = ToMap(n.Children)
+		m[n.Key] = ToMap(n.Children.Arr())
 	}
 	return m
 }
@@ -81,18 +91,21 @@ func makeTree(json map[string]any, layer uint, displayLayers uint, repr ReprNode
 		nodes = append(nodes, node)
 	}
 	slices.SortFunc(nodes, func(a, b *Node) int {
+		// NOTE: limitation of this is if the keys are all
+		// string numbers (IE "1", "2", ...) this will not
+		// order correctly.
 		return strings.Compare(a.Key, b.Key)
 	})
 	return nodes
 }
 
 // IsArray checks if a node represents an array (all children have numeric keys)
-func IsArray(node *Node) bool {
-	if IsLeaf(node) {
+func IsArray(n *Node) bool {
+	if IsLeaf(n) {
 		return false
 	}
-	for _, child := range node.Children {
-		if _, err := strconv.Atoi(child.Key); err != nil {
+	for key := range n.Children.Keys() {
+		if _, err := strconv.Atoi(key); err != nil {
 			return false
 		}
 	}
@@ -101,12 +114,12 @@ func IsArray(node *Node) bool {
 
 // IsLeafArray checks if a node represents an array (all children have numeric keys)
 // and all children are leaf nodes
-func IsLeafArray(node *Node) bool {
-	if IsLeaf(node) {
+func IsLeafArray(n *Node) bool {
+	if IsLeaf(n) {
 		return false
 	}
-	for _, child := range node.Children {
-		if _, err := strconv.Atoi(child.Key); err != nil {
+	for key, child := range n.Children.Iter() {
+		if _, err := strconv.Atoi(key); err != nil {
 			return false
 		}
 		if !IsLeaf(child) {
@@ -133,20 +146,22 @@ func NewNode(key string, value any, layer uint, displayLayers uint, repr ReprNod
 	case bool:
 		node.Value = strconv.FormatBool(v)
 	case []any:
-		node.Children = make([]*Node, 0, len(v))
+		node.Children = omap.New[string, *Node]()
 		for i, child := range v {
-			childNode := NewNode(strconv.FormatUint(uint64(i), 10), child, layer+1, displayLayers, repr)
-			childNode.Parent = node
-			node.Children = append(node.Children, childNode)
+			n := NewNode(strconv.FormatUint(uint64(i), 10), child, layer+1, displayLayers, repr)
+			n.Parent = node
+			node.Children.Put(n.Key, n)
 		}
 		node.Value = "[]"
 		if len(v) > 0 {
 			node.Value = repr(node)
 		}
 	case map[string]any:
-		node.Children = makeTree(v, layer+1, displayLayers, repr)
-		for _, n := range node.Children {
+		node.Children = omap.New[string, *Node]()
+		tree := makeTree(v, layer+1, displayLayers, repr)
+		for _, n := range tree {
 			n.Parent = node
+			node.Children.Put(n.Key, n)
 		}
 		node.Value = "{}"
 		if len(v) > 0 {

--- a/pkg/nodes/nodes_test.go
+++ b/pkg/nodes/nodes_test.go
@@ -1,9 +1,9 @@
 package nodes
 
 import (
-	"sort"
 	"testing"
 
+	"github.com/crosleyzack/xplr/pkg/omap"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,18 +42,17 @@ func TestMakeNode(t *testing.T) {
 			name:  "array value",
 			key:   "array",
 			value: []any{"a", "b", "c"},
-			expected: Node{Key: "array", Value: "a b c", Expand: true, Children: []*Node{
-				{Key: "0", Value: "a", Expand: true},
-				{Key: "1", Value: "b", Expand: true},
-				{Key: "2", Value: "c", Expand: true},
-			}},
+			expected: Node{Key: "array", Value: "a b c", Expand: true, Children: childMap(
+				&Node{Key: "0", Value: "a", Expand: true},
+				&Node{Key: "1", Value: "b", Expand: true},
+				&Node{Key: "2", Value: "c", Expand: true},
+			)},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			node := NewNode(tt.key, tt.value, 0, 2, LeafValuesOnly)
-			sort.Slice(node.Children, sortNodes(node.Children))
 			assert.True(t, compareNodes(node, &tt.expected))
 		})
 	}
@@ -91,21 +90,21 @@ func TestNew(t *testing.T) {
 					Key:    "mixed",
 					Value:  "a 1 true",
 					Expand: true,
-					Children: []*Node{
-						{Key: "0", Value: "a", Expand: true},
-						{Key: "1", Value: "1", Expand: true},
-						{Key: "2", Value: "true", Expand: true},
-					},
+					Children: childMap(
+						&Node{Key: "0", Value: "a", Expand: true},
+						&Node{Key: "1", Value: "1", Expand: true},
+						&Node{Key: "2", Value: "true", Expand: true},
+					),
 				},
 				{
 					Key:    "numbers",
 					Value:  "1 2 3",
 					Expand: true,
-					Children: []*Node{
-						{Key: "0", Value: "1", Expand: true},
-						{Key: "1", Value: "2", Expand: true},
-						{Key: "2", Value: "3", Expand: true},
-					},
+					Children: childMap(
+						&Node{Key: "0", Value: "1", Expand: true},
+						&Node{Key: "1", Value: "2", Expand: true},
+						&Node{Key: "2", Value: "3", Expand: true},
+					),
 				},
 			},
 		},
@@ -119,7 +118,6 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := New(tt.input, 2, LeafValuesOnly)
-			sort.Slice(result, sortNodes(result))
 			if len(result) != len(tt.expected) {
 				t.Errorf("New() returned %d nodes, want %d", len(result), len(tt.expected))
 				return
@@ -159,10 +157,10 @@ func TestToMap(t *testing.T) {
 			nodes: []*Node{
 				{
 					Key: "person",
-					Children: []*Node{
-						{Key: "name", Value: "alice"},
-						{Key: "age", Value: "30"},
-					},
+					Children: childMap(
+						&Node{Key: "name", Value: "alice"},
+						&Node{Key: "age", Value: "30"},
+					),
 				},
 			},
 			expected: map[string]any{
@@ -184,12 +182,19 @@ func TestToMap(t *testing.T) {
 	}
 }
 
-func sortNodes(nodes []*Node) func(i, j int) bool {
-	return func(i, j int) bool { return nodes[i].Key < nodes[j].Key }
+// childMap builds a Children map keyed by each node's Key, matching how the
+// package stores children internally.
+func childMap(children ...*Node) omap.OMap[string, *Node] {
+	m := omap.New[string, *Node]()
+	for _, c := range children {
+		m.Put(c.Key, c)
+	}
+	return m
 }
 
 // compareNodes compares two nodes for equality, including their children.
-// ignores keys
+// ignores ID and Parent so nodes built by NewNode (which assigns random IDs)
+// can be compared against literal expectations.
 func compareNodes(a, b *Node) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -197,11 +202,12 @@ func compareNodes(a, b *Node) bool {
 	if a.Key != b.Key || a.Value != b.Value || a.Expand != b.Expand {
 		return false
 	}
-	if len(a.Children) != len(b.Children) {
+	if a.Children.Len() != b.Children.Len() {
 		return false
 	}
-	for i := range a.Children {
-		if !compareNodes(a.Children[i], b.Children[i]) {
+	for _, child := range a.Children.Arr() {
+		other, ok := b.Children.Get(child.Key)
+		if !ok || !compareNodes(child, other) {
 			return false
 		}
 	}
@@ -217,38 +223,38 @@ func TestIsArray(t *testing.T) {
 		{
 			name: "numeric keys array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "1", Value: "second"},
-					{Key: "2", Value: "third"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "1", Value: "second"},
+					&Node{Key: "2", Value: "third"},
+				),
 			},
 			expected: true,
 		},
 		{
 			name: "mixed keys not array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+				),
 			},
 			expected: false,
 		},
 		{
 			name: "non-sequential numeric keys still array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "2", Value: "third"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "2", Value: "third"},
+				),
 			},
 			expected: true,
 		},
 		{
 			name: "empty children not array",
 			node: &Node{
-				Children: []*Node{},
+				Children: childMap(),
 			},
 			expected: false,
 		},
@@ -262,10 +268,10 @@ func TestIsArray(t *testing.T) {
 		{
 			name: "mixed numeric and string keys not array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "name", Value: "test"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "name", Value: "test"},
+				),
 			},
 			expected: false,
 		},

--- a/pkg/nodes/path.go
+++ b/pkg/nodes/path.go
@@ -1,5 +1,6 @@
 package nodes
 
+// GetPathToNode get path from root to the given node
 func GetPathToNode(n *Node) []string {
 	path := []string{}
 	for current := n; current != nil; current = current.Parent {
@@ -20,18 +21,13 @@ func GetNodeFromPath(root *Node, path []string) (*Node, []string) {
 	current := root
 	remaining := path
 	for _, part := range path {
-		found := false
-		for _, child := range current.Children {
-			if child.Key == part {
-				current = child
-				remaining = remaining[1:]
-				found = true
-				break
-			}
-		}
-		if !found {
+		child := Child(current, part)
+		if child == nil {
+			// no such child, return furthest result along path
 			return current, remaining
 		}
+		current = child
+		remaining = remaining[1:]
 	}
 
 	return current, nil

--- a/pkg/nodes/path_test.go
+++ b/pkg/nodes/path_test.go
@@ -16,12 +16,12 @@ import (
 //	└── sibling2 (bad)
 func buildTestTree() (top, sibling1, sibling2, parent1, leaf *Node) {
 	leaf = &Node{ID: uuid.New(), Key: "target", Value: "hello"}
-	parent1 = &Node{ID: uuid.New(), Key: "final", Children: []*Node{leaf}}
+	parent1 = &Node{ID: uuid.New(), Key: "final", Children: childMap(leaf)}
 	leaf.Parent = parent1
-	sibling1 = &Node{ID: uuid.New(), Key: "bar", Children: []*Node{parent1}}
+	sibling1 = &Node{ID: uuid.New(), Key: "bar", Children: childMap(parent1)}
 	parent1.Parent = sibling1
 	sibling2 = &Node{ID: uuid.New(), Key: "bad"}
-	top = &Node{ID: uuid.New(), Key: "foo", Children: []*Node{sibling1, sibling2}}
+	top = &Node{ID: uuid.New(), Key: "foo", Children: childMap(sibling1, sibling2)}
 	sibling1.Parent = top
 	sibling2.Parent = top
 	return

--- a/pkg/nodes/repr.go
+++ b/pkg/nodes/repr.go
@@ -74,13 +74,13 @@ func leafValuesWithBracketsHelper(n *Node, includeKey bool) string {
 	if includeKey {
 		b.WriteString(n.Key)
 	}
-	if len(n.Children) > 0 {
+	if n.Children.Len() > 0 {
 		if includeKey {
 			b.WriteString(": ")
 		}
 		b.WriteString("{")
 		first := true
-		for _, child := range n.Children {
+		for _, child := range n.Children.Iter() {
 			b.WriteString(spacerToken(first))
 			b.WriteString(leafValuesWithBracketsHelper(child, true))
 			first = false
@@ -99,9 +99,9 @@ func leafValuesWithBracketsHelper(n *Node, includeKey bool) string {
 // LeafValuesOnly represents a node as the sequence of children leaf values only
 func LeafValuesOnly(n *Node) string {
 	var b strings.Builder
-	if len(n.Children) > 0 {
+	if n.Children.Len() > 0 {
 		first := true
-		for _, child := range n.Children {
+		for _, child := range n.Children.Iter() {
 			b.WriteString(spacerToken(first))
 			b.WriteString(LeafValuesOnly(child))
 			first = false
@@ -115,9 +115,9 @@ func LeafValuesOnly(n *Node) string {
 // LeafKeyAndValues represents a node by its leaf node Key and Value
 func LeafKeyAndValues(n *Node) string {
 	var b strings.Builder
-	if len(n.Children) > 0 {
+	if n.Children.Len() > 0 {
 		first := true
-		for _, child := range n.Children {
+		for _, child := range n.Children.Iter() {
 			b.WriteString(spacerToken(first))
 			b.WriteString(LeafKeyAndValues(child))
 			first = false
@@ -133,11 +133,11 @@ func LeafKeyAndValues(n *Node) string {
 // DirectChildrenKeys represents a node as the keys of its direct children
 func DirectChildrenKeys(n *Node) string {
 	var b strings.Builder
-	if len(n.Children) > 0 {
+	if n.Children.Len() > 0 {
 		first := true
-		for _, child := range n.Children {
+		for key := range n.Children.Keys() {
 			b.WriteString(spacerToken(first))
-			b.WriteString(child.Key)
+			b.WriteString(key)
 			first = false
 		}
 	} else {
@@ -149,13 +149,12 @@ func DirectChildrenKeys(n *Node) string {
 // KeyCountOnly represents a node showing only the count of keys/items
 func KeyCountOnly(n *Node) string {
 	var b strings.Builder
-
-	if len(n.Children) > 0 {
+	if count := n.Children.Len(); count > 0 {
 		var metadata string
 		if IsArray(n) {
-			metadata = fmt.Sprintf("(%d items)", len(n.Children))
+			metadata = fmt.Sprintf("(%d items)", count)
 		} else {
-			metadata = fmt.Sprintf("(%d keys)", len(n.Children))
+			metadata = fmt.Sprintf("(%d keys)", count)
 		}
 
 		b.WriteString(MetadataPrefix)
@@ -168,16 +167,16 @@ func KeyCountOnly(n *Node) string {
 // KeyNamesWithTypes represents a node showing key names with their types
 func KeyNamesWithTypes(n *Node) string {
 	var b strings.Builder
-	if len(n.Children) > 0 {
+	if count := n.Children.Len(); count > 0 {
 		var metadata string
 		if IsArray(n) {
 			arrayType := getArrayElementTypes(n)
 			metadata = fmt.Sprintf("(%s)", arrayType)
 		} else {
-			keyDetails := make([]string, 0, len(n.Children))
-			for _, child := range n.Children {
+			keyDetails := make([]string, 0, count)
+			for key, child := range n.Children.Iter() {
 				childType := getJSONType(child)
-				keyDetails = append(keyDetails, fmt.Sprintf("%s:%s", child.Key, childType))
+				keyDetails = append(keyDetails, fmt.Sprintf("%s:%s", key, childType))
 			}
 			metadata = fmt.Sprintf("(%s)", strings.Join(keyDetails, ", "))
 		}
@@ -192,18 +191,18 @@ func KeyNamesWithTypes(n *Node) string {
 // KeyCountAndTypes represents a node showing both count and key names with types
 func KeyCountAndTypes(n *Node) string {
 	var b strings.Builder
-	if len(n.Children) > 0 {
+	if count := n.Children.Len(); count > 0 {
 		var metadata string
 		if IsArray(n) {
 			arrayType := getArrayElementTypes(n)
-			metadata = fmt.Sprintf("(%d items: %s)", len(n.Children), arrayType)
+			metadata = fmt.Sprintf("(%d items: %s)", count, arrayType)
 		} else {
-			keyDetails := make([]string, 0, len(n.Children))
-			for _, child := range n.Children {
+			keyDetails := make([]string, 0, count)
+			for key, child := range n.Children.Iter() {
 				childType := getJSONType(child)
-				keyDetails = append(keyDetails, fmt.Sprintf("%s:%s", child.Key, childType))
+				keyDetails = append(keyDetails, fmt.Sprintf("%s:%s", key, childType))
 			}
-			metadata = fmt.Sprintf("(%d keys: %s)", len(n.Children), strings.Join(keyDetails, ", "))
+			metadata = fmt.Sprintf("(%d keys: %s)", count, strings.Join(keyDetails, ", "))
 		}
 
 		b.WriteString(MetadataPrefix)
@@ -214,15 +213,15 @@ func KeyCountAndTypes(n *Node) string {
 }
 
 // getJSONType determines the JSON type of a node's value
-func getJSONType(node *Node) string {
-	if len(node.Children) > 0 {
-		if IsArray(node) {
+func getJSONType(n *Node) string {
+	if n.Children.Len() > 0 {
+		if IsArray(n) {
 			return "array"
 		}
 		return "object"
 	}
 
-	value := node.Value
+	value := n.Value
 	if value == "" {
 		return "null"
 	}
@@ -239,14 +238,14 @@ func getJSONType(node *Node) string {
 }
 
 // getArrayElementTypes analyzes array elements and returns a descriptive type string
-func getArrayElementTypes(node *Node) string {
-	if !IsArray(node) || IsLeaf(node) {
+func getArrayElementTypes(n *Node) string {
+	if !IsArray(n) || IsLeaf(n) {
 		return "array"
 	}
 
 	// Count types of all elements
 	typeCounts := make(map[string]int)
-	for _, child := range node.Children {
+	for _, child := range n.Children.Iter() {
 		childType := getJSONType(child)
 		typeCounts[childType]++
 	}

--- a/pkg/nodes/repr_test.go
+++ b/pkg/nodes/repr_test.go
@@ -23,10 +23,10 @@ func TestLeafValuesWithBrackets(t *testing.T) {
 			name: "node with children",
 			node: &Node{
 				Key: "parent",
-				Children: []*Node{
-					{Key: "child1", Value: "value1"},
-					{Key: "child2", Value: "value2"},
-				},
+				Children: childMap(
+					&Node{Key: "child1", Value: "value1"},
+					&Node{Key: "child2", Value: "value2"},
+				),
 			},
 			expected: "{child1: value1 child2: value2}",
 		},
@@ -34,14 +34,14 @@ func TestLeafValuesWithBrackets(t *testing.T) {
 			name: "nested children",
 			node: &Node{
 				Key: "root",
-				Children: []*Node{
-					{
+				Children: childMap(
+					&Node{
 						Key: "level1",
-						Children: []*Node{
-							{Key: "level2", Value: "value"},
-						},
+						Children: childMap(
+							&Node{Key: "level2", Value: "value"},
+						),
 					},
-				},
+				),
 			},
 			expected: "{level1: {level2: value}}",
 		},
@@ -49,7 +49,7 @@ func TestLeafValuesWithBrackets(t *testing.T) {
 			name: "empty children",
 			node: &Node{
 				Key:      "empty",
-				Children: []*Node{},
+				Children: childMap(),
 			},
 			expected: "",
 		},
@@ -91,41 +91,42 @@ func TestLeafValuesOnly(t *testing.T) {
 			name: "node with leaf children",
 			node: &Node{
 				Key: "parent",
-				Children: []*Node{
-					{Key: "child1", Value: "value1"},
-					{Key: "child2", Value: "value2"},
-				},
+				Children: childMap(
+					&Node{Key: "child1", Value: "value1"},
+					&Node{Key: "child2", Value: "value2"},
+				),
 			},
 			expected: "value1 value2",
 		},
 		{
+			// children render in key order: "leaf" before "nonleaf".
 			name: "mixed leaf and non-leaf children",
 			node: &Node{
 				Key: "root",
-				Children: []*Node{
-					{
+				Children: childMap(
+					&Node{
 						Key: "nonleaf",
-						Children: []*Node{
-							{Key: "nested", Value: "value"},
-						},
+						Children: childMap(
+							&Node{Key: "nested", Value: "value"},
+						),
 					},
-					{Key: "leaf", Value: "leafvalue"},
-				},
+					&Node{Key: "leaf", Value: "leafvalue"},
+				),
 			},
-			expected: "value leafvalue",
+			expected: "leafvalue value",
 		},
 		{
 			name: "no leaf children",
 			node: &Node{
 				Key: "root",
-				Children: []*Node{
-					{
+				Children: childMap(
+					&Node{
 						Key: "level1",
-						Children: []*Node{
-							{Key: "level2", Children: []*Node{}},
-						},
+						Children: childMap(
+							&Node{Key: "level2", Children: childMap()},
+						),
 					},
-				},
+				),
 			},
 			expected: "",
 		},
@@ -159,10 +160,10 @@ func TestKeyCountOnly(t *testing.T) {
 			name: "simple object with children",
 			node: &Node{
 				Key: "user",
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+				),
 			},
 			expected: MetadataPrefix + "(2 keys)",
 		},
@@ -170,11 +171,11 @@ func TestKeyCountOnly(t *testing.T) {
 			name: "array with items",
 			node: &Node{
 				Key: "items",
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "1", Value: "second"},
-					{Key: "2", Value: "third"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "1", Value: "second"},
+					&Node{Key: "2", Value: "third"},
+				),
 			},
 			expected: MetadataPrefix + "(3 items)",
 		},
@@ -190,7 +191,7 @@ func TestKeyCountOnly(t *testing.T) {
 			name: "empty children array",
 			node: &Node{
 				Key:      "empty",
-				Children: []*Node{},
+				Children: childMap(),
 			},
 			expected: "",
 		},
@@ -213,26 +214,27 @@ func TestKeyNamesWithTypes(t *testing.T) {
 		expected string
 	}{
 		{
+			// keys render in order: active, age, name.
 			name: "object with mixed types",
 			node: &Node{
 				Key: "user",
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-					{Key: "active", Value: "true"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+					&Node{Key: "active", Value: "true"},
+				),
 			},
-			expected: MetadataPrefix + "(name:string, age:integer, active:boolean)",
+			expected: MetadataPrefix + "(active:boolean, age:integer, name:string)",
 		},
 		{
 			name: "array of strings",
 			node: &Node{
 				Key: "colors",
-				Children: []*Node{
-					{Key: "0", Value: "red"},
-					{Key: "1", Value: "blue"},
-					{Key: "2", Value: "green"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "red"},
+					&Node{Key: "1", Value: "blue"},
+					&Node{Key: "2", Value: "green"},
+				),
 			},
 			expected: MetadataPrefix + "(array of strings)",
 		},
@@ -240,11 +242,11 @@ func TestKeyNamesWithTypes(t *testing.T) {
 			name: "array of numbers",
 			node: &Node{
 				Key: "scores",
-				Children: []*Node{
-					{Key: "0", Value: "95"},
-					{Key: "1", Value: "87"},
-					{Key: "2", Value: "92"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "95"},
+					&Node{Key: "1", Value: "87"},
+					&Node{Key: "2", Value: "92"},
+				),
 			},
 			expected: MetadataPrefix + "(array of numbers)",
 		},
@@ -252,11 +254,11 @@ func TestKeyNamesWithTypes(t *testing.T) {
 			name: "array of mixed types",
 			node: &Node{
 				Key: "mixed",
-				Children: []*Node{
-					{Key: "0", Value: "text"},
-					{Key: "1", Value: "42"},
-					{Key: "2", Value: "true"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "text"},
+					&Node{Key: "1", Value: "42"},
+					&Node{Key: "2", Value: "true"},
+				),
 			},
 			expected: MetadataPrefix + "(array)",
 		},
@@ -264,10 +266,10 @@ func TestKeyNamesWithTypes(t *testing.T) {
 			name: "object with nested objects",
 			node: &Node{
 				Key: "data",
-				Children: []*Node{
-					{Key: "config", Children: []*Node{{Key: "debug", Value: "false"}}},
-					{Key: "items", Children: []*Node{{Key: "0", Value: "item1"}}},
-				},
+				Children: childMap(
+					&Node{Key: "config", Children: childMap(&Node{Key: "debug", Value: "false"})},
+					&Node{Key: "items", Children: childMap(&Node{Key: "0", Value: "item1"})},
+				),
 			},
 			expected: MetadataPrefix + "(config:object, items:array)",
 		},
@@ -298,24 +300,25 @@ func TestKeyCountAndTypes(t *testing.T) {
 		expected string
 	}{
 		{
+			// keys render in order: age, name.
 			name: "object with mixed types",
 			node: &Node{
 				Key: "user",
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+				),
 			},
-			expected: MetadataPrefix + "(2 keys: name:string, age:integer)",
+			expected: MetadataPrefix + "(2 keys: age:integer, name:string)",
 		},
 		{
 			name: "array of strings",
 			node: &Node{
 				Key: "tags",
-				Children: []*Node{
-					{Key: "0", Value: "work"},
-					{Key: "1", Value: "personal"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "work"},
+					&Node{Key: "1", Value: "personal"},
+				),
 			},
 			expected: MetadataPrefix + "(2 items: array of strings)",
 		},
@@ -323,9 +326,9 @@ func TestKeyCountAndTypes(t *testing.T) {
 			name: "single item array",
 			node: &Node{
 				Key: "single",
-				Children: []*Node{
-					{Key: "0", Value: "42"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "42"},
+				),
 			},
 			expected: MetadataPrefix + "(1 items: array of numbers)",
 		},
@@ -356,26 +359,27 @@ func TestDirectChildrenKeys(t *testing.T) {
 		expected string
 	}{
 		{
+			// keys render in order: active, age, name.
 			name: "object with children",
 			node: &Node{
 				Key: "user",
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-					{Key: "active", Value: "true"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+					&Node{Key: "active", Value: "true"},
+				),
 			},
-			expected: "name age active",
+			expected: "active age name",
 		},
 		{
 			name: "array with items",
 			node: &Node{
 				Key: "items",
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "1", Value: "second"},
-					{Key: "2", Value: "third"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "1", Value: "second"},
+					&Node{Key: "2", Value: "third"},
+				),
 			},
 			expected: "0 1 2",
 		},
@@ -383,9 +387,9 @@ func TestDirectChildrenKeys(t *testing.T) {
 			name: "single child",
 			node: &Node{
 				Key: "parent",
-				Children: []*Node{
-					{Key: "only_child", Value: "value"},
-				},
+				Children: childMap(
+					&Node{Key: "only_child", Value: "value"},
+				),
 			},
 			expected: "only_child",
 		},
@@ -401,7 +405,7 @@ func TestDirectChildrenKeys(t *testing.T) {
 			name: "empty children array",
 			node: &Node{
 				Key:      "empty",
-				Children: []*Node{},
+				Children: childMap(),
 			},
 			expected: "{}",
 		},
@@ -457,7 +461,7 @@ func TestGetJSONType(t *testing.T) {
 			name: "object with children",
 			node: &Node{
 				Key:      "test",
-				Children: []*Node{{Key: "child", Value: "value"}},
+				Children: childMap(&Node{Key: "child", Value: "value"}),
 			},
 			expected: "object",
 		},
@@ -465,10 +469,10 @@ func TestGetJSONType(t *testing.T) {
 			name: "array with numeric keys",
 			node: &Node{
 				Key: "test",
-				Children: []*Node{
-					{Key: "0", Value: "first"},
-					{Key: "1", Value: "second"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "first"},
+					&Node{Key: "1", Value: "second"},
+				),
 			},
 			expected: "array",
 		},
@@ -493,59 +497,59 @@ func TestGetArrayElementTypes(t *testing.T) {
 		{
 			name: "array of strings",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "hello"},
-					{Key: "1", Value: "world"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "hello"},
+					&Node{Key: "1", Value: "world"},
+				),
 			},
 			expected: "array of strings",
 		},
 		{
 			name: "array of integers",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "1"},
-					{Key: "1", Value: "2"},
-					{Key: "2", Value: "3"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "1"},
+					&Node{Key: "1", Value: "2"},
+					&Node{Key: "2", Value: "3"},
+				),
 			},
 			expected: "array of numbers",
 		},
 		{
 			name: "array of floats",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "1.5"},
-					{Key: "1", Value: "2.7"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "1.5"},
+					&Node{Key: "1", Value: "2.7"},
+				),
 			},
 			expected: "array of numbers",
 		},
 		{
 			name: "mixed type array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "0", Value: "hello"},
-					{Key: "1", Value: "42"},
-					{Key: "2", Value: "true"},
-				},
+				Children: childMap(
+					&Node{Key: "0", Value: "hello"},
+					&Node{Key: "1", Value: "42"},
+					&Node{Key: "2", Value: "true"},
+				),
 			},
 			expected: "array",
 		},
 		{
 			name: "not an array",
 			node: &Node{
-				Children: []*Node{
-					{Key: "name", Value: "John"},
-					{Key: "age", Value: "30"},
-				},
+				Children: childMap(
+					&Node{Key: "name", Value: "John"},
+					&Node{Key: "age", Value: "30"},
+				),
 			},
 			expected: "array",
 		},
 		{
 			name: "empty array",
 			node: &Node{
-				Children: []*Node{},
+				Children: childMap(),
 			},
 			expected: "array",
 		},
@@ -579,9 +583,9 @@ func TestGetRepr(t *testing.T) {
 	// Create a test node
 	testNode := &Node{
 		Key: "test",
-		Children: []*Node{
-			{Key: "child", Value: "value"},
-		},
+		Children: childMap(
+			&Node{Key: "child", Value: "value"},
+		),
 	}
 
 	for _, tt := range tests {
@@ -632,5 +636,4 @@ func TestTruncateIfNeeded(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/nodes/search.go
+++ b/pkg/nodes/search.go
@@ -37,7 +37,7 @@ func dfs(nodes []*Node, f func(*Node, int) error, conf *searchConfig, layer int)
 		}
 		next := conf.NextNodes(node)
 		if len(next) > 0 {
-			if err := dfs(node.Children, f, conf, layer+1); err != nil {
+			if err := dfs(next, f, conf, layer+1); err != nil {
 				return err
 			}
 		}
@@ -72,12 +72,12 @@ func DFSIter(nodes []*Node, f func(*Node) bool, opts ...DFSOption) func(func(*No
 }
 
 func AllChildren(n *Node) []*Node {
-	return n.Children
+	return n.Children.Arr()
 }
 
 func ObeyExpand(n *Node) []*Node {
 	if n.Expand {
-		return n.Children
+		return n.Children.Arr()
 	}
 	return nil
 }

--- a/pkg/nodes/search_test.go
+++ b/pkg/nodes/search_test.go
@@ -9,33 +9,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// testSearchTree builds the standard test tree used across search tests:
+// testSearchTree builds the standard test tree used across search tests.
+// Children iterate in key order, so "bad" is visited before "bar".
 //
 //	foo (expand)
-//	  bar (expand)
-//	    baz
 //	  bad (collapsed)
 //	    unreached
+//	  bar (expand)
+//	    baz
 func testSearchTree() *Node {
 	return &Node{
 		Key:    "foo",
 		Expand: true,
-		Children: []*Node{
-			{
-				Key:    "bar",
-				Expand: true,
-				Children: []*Node{
-					{Key: "baz"},
-				},
+		Children: childMap(
+			&Node{
+				Key:      "bar",
+				Expand:   true,
+				Children: childMap(&Node{Key: "baz"}),
 			},
-			{
-				Key:    "bad",
-				Expand: false,
-				Children: []*Node{
-					{Key: "unreached"},
-				},
+			&Node{
+				Key:      "bad",
+				Expand:   false,
+				Children: childMap(&Node{Key: "unreached"}),
 			},
-		},
+		),
 	}
 }
 
@@ -48,13 +45,13 @@ func TestDFS(t *testing.T) {
 	}{
 		{
 			name:       "default ObeyExpand skips collapsed children",
-			wantKeys:   []string{"foo", "bar", "baz", "bad"},
-			wantLayers: []int{0, 1, 2, 1},
+			wantKeys:   []string{"foo", "bad", "bar", "baz"},
+			wantLayers: []int{0, 1, 1, 2},
 		},
 		{
 			name:       "AllChildren visits all nodes",
 			opts:       []DFSOption{WithNextNodes(AllChildren)},
-			wantKeys:   []string{"foo", "bar", "baz", "bad", "unreached"},
+			wantKeys:   []string{"foo", "bad", "unreached", "bar", "baz"},
 			wantLayers: []int{0, 1, 2, 1, 2},
 		},
 	}
@@ -85,7 +82,7 @@ func TestDFSError(t *testing.T) {
 		return nil
 	})
 	assert.ErrorIs(t, err, sentinel)
-	assert.Equal(t, []string{"foo", "bar"}, visited)
+	assert.Equal(t, []string{"foo", "bad", "bar"}, visited)
 }
 
 func TestDFSIter(t *testing.T) {
@@ -98,18 +95,18 @@ func TestDFSIter(t *testing.T) {
 		{
 			name:     "ObeyExpand",
 			filter:   func(*Node) bool { return true },
-			wantKeys: []string{"foo", "bar", "baz", "bad"},
+			wantKeys: []string{"foo", "bad", "bar", "baz"},
 		},
 		{
 			name:     "match all with AllChildren",
 			filter:   func(*Node) bool { return true },
 			opts:     []DFSOption{WithNextNodes(AllChildren)},
-			wantKeys: []string{"foo", "bar", "baz", "bad", "unreached"},
+			wantKeys: []string{"foo", "bad", "unreached", "bar", "baz"},
 		},
 		{
 			name:     "filter by key substring",
 			filter:   func(n *Node) bool { return strings.Contains(n.Key, "ba") },
-			wantKeys: []string{"bar", "baz", "bad"},
+			wantKeys: []string{"bad", "bar", "baz"},
 		},
 		{
 			name:     "filter matching nothing",
@@ -138,18 +135,18 @@ func TestDFSIterPull(t *testing.T) {
 		{
 			name:     "default ObeyExpand skips collapsed children",
 			filter:   func(*Node) bool { return true },
-			wantKeys: []string{"foo", "bar", "baz", "bad"},
+			wantKeys: []string{"foo", "bad", "bar", "baz"},
 		},
 		{
 			name:     "match all with AllChildren",
 			filter:   func(*Node) bool { return true },
 			opts:     []DFSOption{WithNextNodes(AllChildren)},
-			wantKeys: []string{"foo", "bar", "baz", "bad", "unreached"},
+			wantKeys: []string{"foo", "bad", "unreached", "bar", "baz"},
 		},
 		{
 			name:     "filter by key substring",
 			filter:   func(n *Node) bool { return strings.Contains(n.Key, "ba") },
-			wantKeys: []string{"bar", "baz", "bad"},
+			wantKeys: []string{"bad", "bar", "baz"},
 		},
 	}
 	for _, tt := range tests {
@@ -178,12 +175,12 @@ func TestAllChildren(t *testing.T) {
 	}{
 		{
 			name: "returns children when expanded",
-			node: &Node{Expand: true, Children: []*Node{child}},
+			node: &Node{Expand: true, Children: childMap(child)},
 			want: []*Node{child},
 		},
 		{
 			name: "returns children even when collapsed",
-			node: &Node{Expand: false, Children: []*Node{child}},
+			node: &Node{Expand: false, Children: childMap(child)},
 			want: []*Node{child},
 		},
 		{
@@ -209,12 +206,12 @@ func TestObeyExpand(t *testing.T) {
 	}{
 		{
 			name: "expanded node returns children",
-			node: &Node{Expand: true, Children: []*Node{child}},
+			node: &Node{Expand: true, Children: childMap(child)},
 			want: []*Node{child},
 		},
 		{
 			name: "collapsed node returns nil",
-			node: &Node{Expand: false, Children: []*Node{child}},
+			node: &Node{Expand: false, Children: childMap(child)},
 			want: nil,
 		},
 		{
@@ -240,5 +237,5 @@ func TestWithNextNodes(t *testing.T) {
 		return nil
 	}, WithNextNodes(AllChildren))
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo", "bar", "baz", "bad", "unreached"}, got)
+	assert.Equal(t, []string{"foo", "bad", "unreached", "bar", "baz"}, got)
 }

--- a/pkg/omap/omap.go
+++ b/pkg/omap/omap.go
@@ -1,0 +1,167 @@
+// Package omap provides OMap, an ordered map that keeps its keys sorted.
+package omap
+
+import (
+	"cmp"
+	"iter"
+
+	"github.com/tidwall/btree"
+)
+
+// OMap is a map that keeps its keys in sorted order. It pairs a hash map (for
+// constant-time lookup) with a btree.Set over the keys (for ordered iteration),
+// so lookups stay fast without giving up a stable iteration order.
+//
+// A zero-value OMap is usable but unordered; use New (ordered by default) when
+// you need sorted iteration.
+//
+// Time complexity (n = number of entries):
+//
+//	New     O(1)
+//	Len     O(1)
+//	Get     O(1)
+//	Put     O(log n)
+//	PutAll  O(n log n)
+//	Delete  O(log n)
+//	Keys    O(n) time, O(1) space
+//	Iter    O(n) time, O(1) space
+//	Arr     O(n) time, O(n) space
+//
+// Keys order by the built-in "<": numeric for integer keys, lexicographic for
+// strings.
+type OMap[K cmp.Ordered, V any] struct {
+	mp    map[K]V
+	keys  btree.Set[K]
+	order bool
+}
+
+// options holds the settings applied by New's Option arguments. It is
+// non-generic so WithOrder needs no type arguments; New's type parameters are
+// supplied explicitly at the call site.
+type options struct {
+	order bool
+}
+
+// Option configures an OMap built by New.
+type Option func(*options)
+
+// WithOrder sets whether the OMap maintains sorted key order. Defaults to true;
+// pass false to skip the key btree and use less memory at the cost of ordered
+// iteration.
+func WithOrder(order bool) Option {
+	return func(o *options) { o.order = order }
+}
+
+// New returns an empty OMap. It is ordered by default; pass WithOrder(false) to
+// skip the key btree for lower memory use. Seed it from a map with PutAll.
+//
+// Complexity: O(1).
+func New[K cmp.Ordered, V any](opts ...Option) OMap[K, V] {
+	cfg := options{order: true}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	ret := OMap[K, V]{
+		mp:    make(map[K]V, 0),
+		order: cfg.order,
+	}
+	return ret
+}
+
+// Len returns the number of entries.
+//
+// Complexity: O(1).
+func (o *OMap[K, V]) Len() int {
+	return len(o.mp)
+}
+
+// Get returns the value stored for key and whether it was present.
+//
+// Complexity: O(1).
+func (o *OMap[K, V]) Get(key K) (V, bool) {
+	v, ok := o.mp[key]
+	return v, ok
+}
+
+// Put stores val under key, overwriting any existing value.
+//
+// Complexity: O(log n) — a constant-time map write plus a logarithmic btree
+// insert.
+func (o *OMap[K, V]) Put(key K, val V) {
+	if o.mp == nil {
+		o.mp = make(map[K]V)
+	}
+	o.mp[key] = val
+	if o.order {
+		o.keys.Insert(key)
+	}
+}
+
+// PutAll stores every entry of m, overwriting any existing keys. A nil map is
+// a no-op.
+//
+// Complexity: O(n log n) for n entries (O(n) when unordered).
+func (o *OMap[K, V]) PutAll(m map[K]V) {
+	if m == nil {
+		return
+	}
+	for k, v := range m {
+		o.Put(k, v)
+	}
+}
+
+// Keys returns an iterator over the keys in ascending order.
+//
+// Complexity: O(n) time, O(1) space.
+func (o *OMap[K, V]) Keys() iter.Seq[K] {
+	if o.order {
+		return func(yield func(K) bool) {
+			o.keys.Scan(yield) // Scan's callback IS func(K) bool
+		}
+	}
+	return func(yield func(K) bool) {
+		for key := range o.mp {
+			if !yield(key) {
+				return
+			}
+		}
+	}
+}
+
+// Iter returns an iterator over the key/value pairs in ascending key order.
+//
+// Complexity: O(1) to obtain the iterator; consuming it is O(n) time and O(1)
+// space (it streams over the key btree without allocating a snapshot).
+func (o *OMap[K, V]) Iter() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for key := range o.Keys() {
+			if !yield(key, o.mp[key]) {
+				return
+			}
+		}
+	}
+}
+
+// Arr returns all values as a slice in ascending key order, or nil if empty.
+//
+// Complexity: O(n) time and space.
+func (o *OMap[K, V]) Arr() []V {
+	if o.Len() == 0 {
+		return nil
+	}
+	ret := make([]V, 0, o.Len())
+	for _, v := range o.Iter() {
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+// Delete removes key and its value. Deleting an absent key is a no-op.
+//
+// Complexity: O(log n).
+func (o *OMap[K, V]) Delete(key K) {
+	delete(o.mp, key)
+	if o.order {
+		o.keys.Delete(key)
+	}
+}

--- a/pkg/omap/omap_test.go
+++ b/pkg/omap/omap_test.go
@@ -1,0 +1,225 @@
+package omap
+
+import (
+	"cmp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// vals collects the values yielded by Iter, in iteration order.
+func vals[K cmp.Ordered, V any](o *OMap[K, V]) []V {
+	var out []V
+	for _, v := range o.Iter() {
+		out = append(out, v)
+	}
+	return out
+}
+
+// keysOf collects the keys yielded by Keys, in iteration order.
+func keysOf[K cmp.Ordered, V any](o *OMap[K, V]) []K {
+	var out []K
+	for k := range o.Keys() {
+		out = append(out, k)
+	}
+	return out
+}
+
+// seed builds an OMap in the given order mode and fills it from m via PutAll.
+func seed[K cmp.Ordered, V any](order bool, m map[K]V) OMap[K, V] {
+	o := New[K, V](WithOrder(order))
+	o.PutAll(m)
+	return o
+}
+
+// orderModes drives tests that must hold in both ordered and unordered mode.
+var orderModes = []struct {
+	name  string
+	order bool
+}{
+	{name: "ordered", order: true},
+	{name: "unordered", order: false},
+}
+
+func TestNew(t *testing.T) {
+	t.Run("empty and ordered by default", func(t *testing.T) {
+		o := New[string, int]()
+		assert.Equal(t, 0, o.Len())
+		assert.Nil(t, o.Arr())
+		o.Put("b", 2)
+		o.Put("a", 1)
+		assert.Equal(t, []int{1, 2}, vals(&o)) // ordered
+	})
+
+	t.Run("unordered skips sorting", func(t *testing.T) {
+		o := New[string, int](WithOrder(false))
+		o.Put("b", 2)
+		o.Put("a", 1)
+		assert.ElementsMatch(t, []int{1, 2}, vals(&o))
+	})
+}
+
+func TestPutAll(t *testing.T) {
+	for _, mode := range orderModes {
+		t.Run(mode.name, func(t *testing.T) {
+			o := New[string, int](WithOrder(mode.order))
+			o.PutAll(map[string]int{"a": 1, "b": 2})
+			o.PutAll(map[string]int{"b": 20, "c": 3}) // overwrites b, adds c
+			o.PutAll(nil)                             // no-op
+			assert.Equal(t, 3, o.Len())
+
+			if mode.order {
+				assert.Equal(t, []int{1, 20, 3}, vals(&o)) // a, b, c ascending
+			} else {
+				assert.ElementsMatch(t, []int{1, 20, 3}, vals(&o))
+			}
+		})
+	}
+}
+
+func TestLen(t *testing.T) {
+	for _, mode := range orderModes {
+		t.Run(mode.name, func(t *testing.T) {
+			empty := New[string, int](WithOrder(mode.order))
+			assert.Equal(t, 0, empty.Len())
+			three := seed(mode.order, map[string]int{"a": 1, "b": 2, "c": 3})
+			assert.Equal(t, 3, three.Len())
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	for _, mode := range orderModes {
+		t.Run(mode.name, func(t *testing.T) {
+			o := seed(mode.order, map[string]int{"a": 1, "b": 2})
+			got, ok := o.Get("a")
+			assert.True(t, ok)
+			assert.Equal(t, 1, got)
+			_, ok = o.Get("z")
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestPut(t *testing.T) {
+	for _, mode := range orderModes {
+		t.Run(mode.name, func(t *testing.T) {
+			o := New[string, int](WithOrder(mode.order))
+			o.Put("b", 2)
+			o.Put("a", 1)
+			o.Put("a", 9) // overwrite, must not grow
+			assert.Equal(t, 2, o.Len())
+			got, _ := o.Get("a")
+			assert.Equal(t, 9, got)
+			assert.ElementsMatch(t, []int{9, 2}, vals(&o))
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	for _, mode := range orderModes {
+		t.Run(mode.name, func(t *testing.T) {
+			o := seed(mode.order, map[string]int{"a": 1, "b": 2, "c": 3})
+			o.Delete("b")
+			o.Delete("z") // absent: no-op
+			assert.Equal(t, 2, o.Len())
+			_, ok := o.Get("b")
+			assert.False(t, ok)
+			assert.ElementsMatch(t, []int{1, 3}, vals(&o))
+		})
+	}
+}
+
+func TestKeys(t *testing.T) {
+	in := map[string]int{"c": 3, "a": 1, "b": 2}
+	t.Run("ordered ascending", func(t *testing.T) {
+		o := seed(true, in)
+		assert.Equal(t, []string{"a", "b", "c"}, keysOf(&o))
+	})
+	t.Run("unordered has all keys", func(t *testing.T) {
+		o := seed(false, in)
+		assert.ElementsMatch(t, []string{"a", "b", "c"}, keysOf(&o))
+	})
+	t.Run("empty", func(t *testing.T) {
+		o := New[string, int]()
+		assert.Empty(t, keysOf(&o))
+	})
+}
+
+func TestArr(t *testing.T) {
+	in := map[string]int{"c": 3, "a": 1, "b": 2}
+	t.Run("ordered ascending", func(t *testing.T) {
+		o := seed(true, in)
+		assert.Equal(t, []int{1, 2, 3}, o.Arr())
+	})
+	t.Run("unordered has all values", func(t *testing.T) {
+		o := seed(false, in)
+		assert.ElementsMatch(t, []int{1, 2, 3}, o.Arr())
+	})
+	t.Run("empty returns nil", func(t *testing.T) {
+		o := New[string, int]()
+		assert.Nil(t, o.Arr())
+	})
+}
+
+func TestIter(t *testing.T) {
+	in := map[string]int{"c": 3, "a": 1, "b": 2}
+	t.Run("ordered yields pairs in key order", func(t *testing.T) {
+		o := seed(true, in)
+		var ks []string
+		var vs []int
+		for k, v := range o.Iter() {
+			ks = append(ks, k)
+			vs = append(vs, v)
+		}
+		assert.Equal(t, []string{"a", "b", "c"}, ks)
+		assert.Equal(t, []int{1, 2, 3}, vs)
+	})
+	t.Run("unordered yields all pairs", func(t *testing.T) {
+		o := seed(false, in)
+		got := map[string]int{}
+		for k, v := range o.Iter() {
+			got[k] = v
+		}
+		assert.Equal(t, in, got)
+	})
+}
+
+func TestIterEarlyStop(t *testing.T) {
+	o := seed(true, map[string]int{"a": 1, "b": 2, "c": 3})
+	var got []int
+	for _, v := range o.Iter() {
+		got = append(got, v)
+		if len(got) == 2 {
+			break // exercises the yield-returns-false path
+		}
+	}
+	assert.Equal(t, []int{1, 2}, got)
+}
+
+// TestZeroValueUsableUnordered documents that a zero-value OMap works but is
+// unordered (the btree is only built when ordered).
+func TestZeroValueUsableUnordered(t *testing.T) {
+	var o OMap[string, int]
+	assert.NotPanics(t, func() {
+		o.Put("b", 2)
+		o.Put("a", 1)
+	})
+	got, ok := o.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, 1, got)
+	assert.ElementsMatch(t, []int{1, 2}, o.Arr())
+}
+
+// TestOrderingIntKeys documents that integer keys iterate in numeric order.
+func TestOrderingIntKeys(t *testing.T) {
+	o := seed(true, map[int]string{10: "ten", 2: "two", 1: "one", 3: "three"})
+	assert.Equal(t, []string{"one", "two", "three", "ten"}, vals(&o))
+}
+
+// TestOrderingStringKeysLexicographic documents that string keys iterate in
+// lexicographic order, so numeric-looking keys sort as text ("10" before "2").
+func TestOrderingStringKeysLexicographic(t *testing.T) {
+	o := seed(true, map[string]int{"0": 0, "1": 1, "2": 2, "10": 10})
+	assert.Equal(t, []int{0, 1, 10, 2}, vals(&o))
+}


### PR DESCRIPTION
Store children of nodes as an ordered map for efficient key lookups and ordered iteration