### PR TITLE
n trees provided to diff arg

### DIFF
--- a/cmds/cmd.go
+++ b/cmds/cmd.go
@@ -34,13 +34,17 @@ func New() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to parse config: %w", err)
 			}
-			// get data
-			data, err := getData(getSafe(args, 0), file)
+			// gather every operand from files, arguments and a piped stdin.
+			inputs, err := gatherInputs(args, []string{file}, os.Stdin)
 			if err != nil {
 				return fmt.Errorf("failed to get data: %w", err)
 			}
+			if len(inputs) != 1 {
+				return fmt.Errorf("diff needs exactly one input, got %d", len(inputs))
+			}
+
 			// get data as map[string]any
-			m, err := format.Parse(data)
+			m, err := format.Parse(inputs[0])
 			if err != nil {
 				return fmt.Errorf("failed to parse data: %w", err)
 			}
@@ -60,28 +64,39 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func getData(args, file string) (data []byte, err error) {
-	if args != "" {
-		data = []byte(args)
-	} else if file != "" {
-		f, err := os.Open(file)
+// gatherInputs gathers operands in a stable order: one entry per file (in the
+// order given), then one per positional argument treated as inline data, then
+// stdin when it is piped and not empty. stdin is a parameter so callers can test
+// it without touching the real os.Stdin.
+func gatherInputs(args, files []string, stdin *os.File) ([][]byte, error) {
+	var out [][]byte
+	for _, f := range files {
+		b, err := os.ReadFile(f)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open data file: %w", err)
+			return nil, fmt.Errorf("failed to read file %s: %w", f, err)
 		}
-		data, err = io.ReadAll(f)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file: %w", err)
-		}
-	} else {
-		data, err = io.ReadAll(os.Stdin)
+		out = append(out, b)
+	}
+	for _, a := range args {
+		out = append(out, []byte(a))
+	}
+	if piped(stdin) {
+		b, err := io.ReadAll(stdin)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read from pipe: %w", err)
 		}
+		if len(b) > 0 {
+			out = append(out, b)
+		}
 	}
-	if len(data) == 0 {
-		return nil, fmt.Errorf("no data")
-	}
-	return data, nil
+	return out, nil
+}
+
+// piped reports whether f is a pipe or redirect rather than an interactive
+// terminal, meaning it carries data to read.
+func piped(f *os.File) bool {
+	st, err := f.Stat()
+	return err == nil && st.Mode()&os.ModeCharDevice == 0
 }
 
 // renderTree takes in a config and a node tree and renders the TUI tree interface
@@ -104,12 +119,4 @@ func renderTree(conf *tui.Config, n *nodes.Node) error {
 		return err
 	}
 	return nil
-}
-
-func getSafe[T any](arr []T, idx int) T {
-	if idx < 0 || idx >= len(arr) {
-		var zero T
-		return zero
-	}
-	return arr[idx]
 }

--- a/cmds/diff.go
+++ b/cmds/diff.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/crosleyzack/xplr/pkg/format"
 	"github.com/crosleyzack/xplr/pkg/nodes"
@@ -10,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NOTE: current limitation of this is it will not show items in
-// tree2 that are not in tree1, as it only does a single dfs over tree1
-// TODO: fix the above, and make this work with N trees
+// NewDiffCmd builds the `diff` command. It compares N trees drawn from any mix
+// of files (-f), positional arguments, and a piped stdin, walking them together
+// with DFSMulti so nodes present in only some trees still appear in the diff.
 func NewDiffCmd() *cobra.Command {
 	var files, keys []string
 	var output string
@@ -21,48 +22,50 @@ func NewDiffCmd() *cobra.Command {
 		Use:     "diff []",
 		Aliases: []string{"d"},
 		Version: "0.2.5",
-		Short:   "Diff two tree data files with a TUI graphical interface",
-		Long:    "Takes in two tree data files (JSON, YAML, TOML) either via flag parameter to compare the two files.",
+		Short:   "Diff two or more tree data files with a TUI graphical interface",
+		Long:    "Takes in two or more tree data sources (JSON, YAML, TOML) via file flags, positional arguments, or a piped stdin and compares them.",
 		Example: "xplr diff -f foo.json -f bar.json",
-		Args:    cobra.MaximumNArgs(2),
+		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			// get config
 			c, err := tui.NewConfig()
 			if err != nil {
 				return fmt.Errorf("failed to parse config: %w", err)
 			}
-			d1, err := getData(getSafe(args, 0), getSafe(files, 0))
+			// gather every operand from files, arguments and a piped stdin.
+			inputs, err := gatherInputs(args, files, os.Stdin)
 			if err != nil {
 				return fmt.Errorf("failed to get data: %w", err)
 			}
-			d2, err := getData(getSafe(args, 1), getSafe(files, 1))
-			if err != nil {
-				return fmt.Errorf("failed to get data: %w", err)
+			if len(inputs) != 2 {
+				// TODO: relax once n diff implemented
+				return fmt.Errorf("diff needs exactly two inputs, got %d", len(inputs))
 			}
 
-			// get keys
-			if len(keys) != 2 {
-				return fmt.Errorf("two keys required, got %d", len(keys))
+			// keys default to _f1.._fN; when supplied, one is required per input.
+			if len(keys) == 0 {
+				keys = defaultKeys(len(inputs))
 			}
-			key1 := keys[0]
-			key2 := keys[1]
-
-			// get data as map[string]any
-			m1, err := format.Parse(d1)
-			if err != nil {
-				return fmt.Errorf("failed to parse data: %w", err)
-			}
-			m2, err := format.Parse(d2)
-			if err != nil {
-				return fmt.Errorf("failed to parse data: %w", err)
+			if len(keys) != len(inputs) {
+				return fmt.Errorf("need one key per input: got %d keys for %d inputs", len(keys), len(inputs))
 			}
 
-			tree1 := nodes.New(m1, 0, nodes.EmptyRepr)
-			tree2 := nodes.New(m2, 0, nodes.EmptyRepr)
+			// parse each input into its own tree.
+			trees := make([]*nodes.Node, len(inputs))
+			for i, in := range inputs {
+				m, err := format.Parse(in)
+				if err != nil {
+					return fmt.Errorf("failed to parse input %d: %w", i+1, err)
+				}
+				trees[i] = nodes.New(m, 0, nodes.EmptyRepr)
+			}
+
 			diffTree, err := createDiffTree(
-				tree1, tree2,
-				WithKeyOne(key1),
-				WithKeyTwo(key2),
+				trees[0],
+				trees[1],
+				WithKeyOne(keys[0]),
+				WithKeyTwo(keys[1]),
+				WithNilValue(nilValue),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create diff tree: %w", err)
@@ -72,7 +75,7 @@ func NewDiffCmd() *cobra.Command {
 				return fmt.Errorf("failed to update tree repr: %w", err)
 			}
 			// add meta
-			diffTree, err = addMeta(diffTree, c, key1, key2)
+			diffTree, err = addMeta(diffTree, c, keys...)
 			if err != nil {
 				return fmt.Errorf("failed to add tree meta: %w", err)
 			}
@@ -105,9 +108,18 @@ func NewDiffCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&files, "file", "f", nil, "files to read data from")
 	cmd.Flags().StringVarP(&output, "out", "o", "", "what to output the diff to (defaults to tree display)")
 
-	cmd.Flags().StringSliceVarP(&keys, "key", "k", []string{"_f1", "_f2"}, "what to put as key in tree to denote this is from tree1")
+	cmd.Flags().StringSliceVarP(&keys, "key", "k", nil, "key to label each input in the diff (one per input, defaults to _f1.._fN)")
 	cmd.Flags().StringVar(&nilValue, "nilValue", "nil", "what to use as value for missing nodes in one tree")
 	return cmd
+}
+
+// defaultKeys returns the default label for each of n inputs: _f1, _f2, ... _fn.
+func defaultKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("_f%d", i+1)
+	}
+	return keys
 }
 
 // nodesEquivalent compares two nodes and returns true if they are equal, false otherwise
@@ -116,6 +128,9 @@ func NewDiffCmd() *cobra.Command {
 func nodesEquivalent(n1, n2 *nodes.Node) bool {
 	if (n1 == nil) != (n2 == nil) {
 		return false
+	}
+	if n1 == nil && n2 == nil {
+		return true
 	}
 	n1IsLeaf := nodes.IsLeaf(n1)
 	n2IsLeaf := nodes.IsLeaf(n2)
@@ -342,25 +357,23 @@ func copyNode(n *nodes.Node) *nodes.Node {
 
 var defaultDiffColors = []string{"#ad0116", "#006222"}
 
-func addMeta(tree *nodes.Node, conf *tui.Config, key1 string, key2 string) (*nodes.Node, error) {
+func addMeta(tree *nodes.Node, conf *tui.Config, keys ...string) (*nodes.Node, error) {
 	colors := conf.DiffColors
-	if len(colors) < 2 {
+	if len(colors) < len(keys) {
+		// not enough configured colors; fall back to the defaults and cycle
+		// through them for any extra inputs.
 		colors = defaultDiffColors
 	}
 	var err error
-	tree, err = addNode(
-		tree, []string{nodes.MetaKey},
-		nodes.NewNode(key1, colors[0], 1, 0, nodes.LeafKeyAndValues),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to add meta for %s: %w", key1, err)
-	}
-	tree, err = addNode(
-		tree, []string{nodes.MetaKey},
-		nodes.NewNode(key2, colors[1], 1, 0, nodes.LeafKeyAndValues),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to add meta for %s: %w", key2, err)
+	for i, key := range keys {
+		color := colors[i%len(colors)]
+		tree, err = addNode(
+			tree, []string{nodes.MetaKey},
+			nodes.NewNode(key, color, 1, 0, nodes.LeafKeyAndValues),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add meta for %s: %w", key, err)
+		}
 	}
 	return tree, nil
 }

--- a/cmds/diff_test.go
+++ b/cmds/diff_test.go
@@ -1,16 +1,19 @@
 package cmds
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/crosleyzack/xplr/pkg/nodes"
+	"github.com/crosleyzack/xplr/pkg/tui"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompareNodes(t *testing.T) {
+func TestNodesEquivalent(t *testing.T) {
 	leaf := func(key, value string) *nodes.Node {
 		return &nodes.Node{ID: uuid.New(), Key: key, Value: value}
 	}
@@ -27,62 +30,60 @@ func TestCompareNodes(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		n1, n2   *nodes.Node
+		nodes    []*nodes.Node
 		expected bool
 	}{
+		// pairwise cases
 		{
 			name:     "equal leaf nodes",
-			n1:       leaf("x", "v"),
-			n2:       leaf("x", "v"),
+			nodes:    []*nodes.Node{leaf("x", "v"), leaf("x", "v")},
+			expected: true,
+		},
+		{
+			name:     "both nil are equivalent",
+			nodes:    []*nodes.Node{nil, nil},
 			expected: true,
 		},
 		{
 			name:     "n1 nil n2 non-nil",
-			n1:       nil,
-			n2:       leaf("x", "v"),
+			nodes:    []*nodes.Node{nil, leaf("x", "v")},
 			expected: false,
 		},
 		{
 			name:     "n1 non-nil n2 nil",
-			n1:       leaf("x", "v"),
-			n2:       nil,
+			nodes:    []*nodes.Node{leaf("x", "v"), nil},
 			expected: false,
 		},
 		{
 			name:     "different keys",
-			n1:       leaf("a", "v"),
-			n2:       leaf("b", "v"),
+			nodes:    []*nodes.Node{leaf("a", "v"), leaf("b", "v")},
 			expected: false,
 		},
 		{
 			name:     "different values",
-			n1:       leaf("x", "1"),
-			n2:       leaf("x", "2"),
+			nodes:    []*nodes.Node{leaf("x", "1"), leaf("x", "2")},
 			expected: false,
 		},
 		{
 			name:     "one leaf one non-leaf",
-			n1:       leaf("x", "v"),
-			n2:       nonLeaf("x", leaf("c", "v")),
+			nodes:    []*nodes.Node{leaf("x", "v"), nonLeaf("x", leaf("c", "v"))},
 			expected: false,
 		},
 		{
 			name:     "leaf array vs non-array non-leaf",
-			n1:       leafArray("x"),
-			n2:       nonLeaf("x", leaf("a", "v"), leaf("b", "v")),
+			nodes:    []*nodes.Node{leafArray("x"), nonLeaf("x", leaf("a", "v"), leaf("b", "v"))},
 			expected: false,
 		},
 		{
 			name:     "equal non-leaf nodes",
-			n1:       nonLeaf("x", leaf("c", "v")),
-			n2:       nonLeaf("x", leaf("c", "v")),
+			nodes:    []*nodes.Node{nonLeaf("x", leaf("c", "v")), nonLeaf("x", leaf("c", "v"))},
 			expected: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, nodesEquivalent(tt.n1, tt.n2))
+			assert.Equal(t, tt.expected, nodesEquivalent(tt.nodes[0], tt.nodes[1]))
 		})
 	}
 }
@@ -281,6 +282,169 @@ func TestCreateDiffTree(t *testing.T) {
 			diff, err := createDiffTree(tree1, tree2)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, nodes.ToMap(diff.Children.Arr()...))
+		})
+	}
+}
+
+func TestGatherInputs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+		return p
+	}
+	fileA := writeFile("a.json", "AAA")
+	fileB := writeFile("b.json", "BBB")
+	stdinFile := writeFile("stdin.json", "SSS")
+
+	// os.DevNull is a character device, so piped() is false and stdin is
+	// ignored; a regular file is not, so it is read as a piped source.
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	t.Cleanup(func() { devNull.Close() })
+
+	tests := []struct {
+		name     string
+		args     []string
+		files    []string
+		useStdin bool
+		want     [][]byte
+	}{
+		{
+			name:  "files only in flag order",
+			files: []string{fileA, fileB},
+			want:  [][]byte{[]byte("AAA"), []byte("BBB")},
+		},
+		{
+			name: "args only as inline data",
+			args: []string{"one", "two"},
+			want: [][]byte{[]byte("one"), []byte("two")},
+		},
+		{
+			name:  "files come before args",
+			files: []string{fileA},
+			args:  []string{"arg"},
+			want:  [][]byte{[]byte("AAA"), []byte("arg")},
+		},
+		{
+			name:     "stdin comes last",
+			files:    []string{fileA},
+			args:     []string{"arg"},
+			useStdin: true,
+			want:     [][]byte{[]byte("AAA"), []byte("arg"), []byte("SSS")},
+		},
+		{
+			name:     "stdin only",
+			useStdin: true,
+			want:     [][]byte{[]byte("SSS")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdin := devNull
+			if tt.useStdin {
+				f, err := os.Open(stdinFile)
+				require.NoError(t, err)
+				t.Cleanup(func() { f.Close() })
+				stdin = f
+			}
+			got, err := gatherInputs(tt.args, tt.files, stdin)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGatherInputsEmptyStdinSkipped(t *testing.T) {
+	// a piped but empty stdin adds no operand.
+	empty := filepath.Join(t.TempDir(), "empty")
+	require.NoError(t, os.WriteFile(empty, nil, 0o600))
+	f, err := os.Open(empty)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	got, err := gatherInputs([]string{"x"}, nil, f)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("x")}, got)
+}
+
+func TestGatherInputsFileError(t *testing.T) {
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	t.Cleanup(func() { devNull.Close() })
+
+	_, err = gatherInputs(nil, []string{filepath.Join(t.TempDir(), "missing.json")}, devNull)
+	require.Error(t, err)
+}
+
+func TestDefaultKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want []string
+	}{
+		{name: "zero", n: 0, want: []string{}},
+		{name: "one", n: 1, want: []string{"_f1"}},
+		{name: "three", n: 3, want: []string{"_f1", "_f2", "_f3"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, defaultKeys(tt.n))
+		})
+	}
+}
+
+func TestAddMeta(t *testing.T) {
+	// metaColors returns the color value stored for each key under the meta node.
+	metaColors := func(tree *nodes.Node) map[string]string {
+		m := map[string]string{}
+		meta := nodes.Child(tree, nodes.MetaKey)
+		if meta == nil {
+			return m
+		}
+		for k, child := range meta.Children.Iter() {
+			m[k] = child.Value
+		}
+		return m
+	}
+
+	tests := []struct {
+		name       string
+		diffColors []string
+		keys       []string
+		want       map[string]string
+	}{
+		{
+			name:       "two keys use configured colors",
+			diffColors: []string{"#111", "#222"},
+			keys:       []string{"_f1", "_f2"},
+			want:       map[string]string{"_f1": "#111", "_f2": "#222"},
+		},
+		{
+			name:       "three keys with enough configured colors",
+			diffColors: []string{"#111", "#222", "#333"},
+			keys:       []string{"_f1", "_f2", "_f3"},
+			want:       map[string]string{"_f1": "#111", "_f2": "#222", "_f3": "#333"},
+		},
+		{
+			name:       "too few colors fall back to defaults and cycle",
+			diffColors: []string{"#111"},
+			keys:       []string{"_f1", "_f2", "_f3"},
+			want: map[string]string{
+				"_f1": defaultDiffColors[0],
+				"_f2": defaultDiffColors[1],
+				"_f3": defaultDiffColors[0],
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &tui.Config{}
+			conf.DiffColors = tt.diffColors
+			tree := nodes.New(map[string]any{}, 0, nodes.EmptyRepr)
+			tree, err := addMeta(tree, conf, tt.keys...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, metaColors(tree))
 		})
 	}
 }


### PR DESCRIPTION
### What

Generalizes input parsing to handle N arguments, though artificially capped at 2 for now

### Why

This will allow the diff command to generalize to >2 trees at once