### PR TITLE
fix: newNode sets repr value for nodes with children

### DIFF
--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -171,7 +171,7 @@ func NewNode(key string, value any, layer uint, displayLayers uint, repr ReprNod
 			addChild(node, n)
 		}
 		node.Value = "[]"
-		if len(v) > 0 {
+		if node.Children.Len() > 0 {
 			node.Value = repr(node)
 		}
 	case map[string]any:
@@ -179,6 +179,10 @@ func NewNode(key string, value any, layer uint, displayLayers uint, repr ReprNod
 		// layer deeper.
 		node = makeTree(v, layer, displayLayers, repr)
 		node.Key = key
+		node.Value = "{}"
+		if node.Children.Len() > 0 {
+			node.Value = repr(node)
+		}
 	}
 	return node
 }

--- a/pkg/nodes/nodes_test.go
+++ b/pkg/nodes/nodes_test.go
@@ -48,6 +48,21 @@ func TestMakeNode(t *testing.T) {
 				&Node{Key: "2", Value: "c", Expand: true},
 			)},
 		},
+		{
+			name:  "map value sets Value via repr",
+			key:   "map",
+			value: map[string]any{"b": "2", "a": "1"},
+			expected: Node{Key: "map", Value: "1 2", Expand: true, Children: childMap(
+				&Node{Key: "a", Value: "1", Expand: true},
+				&Node{Key: "b", Value: "2", Expand: true},
+			)},
+		},
+		{
+			name:     "empty map value",
+			key:      "map",
+			value:    map[string]any{},
+			expected: Node{Key: "map", Value: "{}", Expand: true, Children: childMap()},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What

NewNode should use repr method to generate value for nodes with children